### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         cache: true
     - name: Describe plugin
       id: plugin_describe
-      run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
+      run: echo "api_version=$(go run . describe | jq -r '.api_version')" >> $GITHUB_OUTPUT
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v4
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,33 +1,41 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
 env:
   - CGO_ENABLED=0
+before:
+  hooks:
+    # We strongly recommend running tests to catch any regression before release.
+    # Even though, this an optional step.
+    - go test ./...
+    # As part of the release doc files are included as a separate deliverable for
+    # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
+    #- make ci-release-docs
+    # Check plugin compatibility with required version of the Packer SDK
+    - make plugin-check
 builds:
   # A separated build to run the packer-plugins-check only once for a linux_amd64 binary
   -
     id: plugin-check
     mod_timestamp: '{{ .CommitTimestamp }}'
-    hooks:
-      post:
-        # This will check plugin compatibility against latest version of Packer
-        - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
-            packer-plugins-check -load={{ .Name }}
-          dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
-      - '-s -w -X main.Version={{.Version}} -X main.VersionPrerelease= '
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     goos:
       - linux
     goarch:
       - amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
-  - 
+  -
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.VersionPrerelease= '
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     goos:
+      - netbsd
+      - solaris
+      - openbsd
       - freebsd
       - windows
       - linux
@@ -38,6 +46,8 @@ builds:
       - arm
       - arm64
     ignore:
+      - goos: openbsd
+        goarch: arm64
       - goos: darwin
         goarch: '386'
       - goos: linux
@@ -45,6 +55,9 @@ builds:
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 archives:
 - format: zip
+  rlcp: true
+  files:
+    - none*
   name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 default: build
 
+NAME=amazon-ami-management
+BINARY=packer-plugin-${NAME}
 MOCK_VERSION?=$(shell go list -m github.com/golang/mock | cut -d " " -f2)
 SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
 
@@ -20,4 +22,7 @@ install: build
 	mkdir -p ~/.packer.d/plugins
 	mv ./packer-plugin-amazon-ami-management ~/.packer.d/plugins/
 
-.PHONY: default deps test build install
+plugin-check: deps build
+	packer-sdc plugin-check ${BINARY}
+
+.PHONY: default deps generate test build install plugin-check


### PR DESCRIPTION
See https://github.com/wata727/packer-plugin-amazon-ami-management/actions/runs/3845774636/jobs/6550316143

- Update goreleaser config
- Add `make plugin-check`
- Migrate `set-output` to `$GITHUB_OUTPUT`