### PR TITLE
feat: search by tags provided in free style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # packer-plugin-amazon-ami-management
+
 [![Build Status](https://github.com/wata727/packer-plugin-amazon-ami-management/workflows/build/badge.svg?branch=master)](https://github.com/wata727/packer-plugin-amazon-ami-management/actions)
 [![GitHub release](https://img.shields.io/github/release/wata727/packer-plugin-amazon-ami-management.svg)](https://github.com/wata727/packer-plugin-amazon-ami-management/releases/latest)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-blue.svg)](LICENSE)
@@ -6,9 +7,11 @@
 Packer post-processor plugin for Amazon AMI management
 
 ## Description
+
 This post-processor cleanups old AMIs and EBS snapshots after baking a new AMI.
 
 ## Installation
+
 Packer >= v1.7.0 supports third-party plugin installation by `init` command. You can install the plugin automatically after adding the `required_plugin` block.
 
 ```hcl
@@ -25,19 +28,24 @@ packer {
 See the [Packer documentation](https://www.packer.io/docs/plugins#installing-plugins) for more details.
 
 ## Usage
+
 The following example is a template to keep only the latest 3 AMIs.
 
 ```hcl
-source "amazon-ebs" "example" {
-  region = "us-east-1"
-  source_ami = "ami-6869aa05"
-  instance_type = "t2.micro"
-  ssh_username = "ec2-user"
-  ssh_pty = true
-  ami_name = "packer-example ${formatdate("YYYYMMDDhhmmss", timestamp())}"
+locals {
   tags = {
     Amazon_AMI_Management_Identifier = "packer-example"
   }
+}
+
+source "amazon-ebs" "example" {
+  region        = "us-east-1"
+  source_ami    = "ami-6869aa05"
+  instance_type = "t2.micro"
+  ssh_username  = "ec2-user"
+  ssh_pty       = true
+  ami_name      = "packer-example ${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  tags          = local.tags
 }
 
 build {
@@ -48,9 +56,9 @@ build {
   }
 
   post-processor "amazon-ami-management" {
-    regions = ["us-east-1"]
-    identifier = "packer-example"
+    regions       = ["us-east-1"]
     keep_releases = 3
+    tags          = local.tags
   }
 }
 ```
@@ -60,13 +68,15 @@ build {
 Type: `amazon-ami-management`
 
 Required:
-  - `identifier` (string) - An identifier of AMIs. This plugin looks `Amazon_AMI_Management_Identifier` tag. If `identifier` matches tag value, these AMI becomes to management target.
-  - `keep_releases` (integer) - The number of AMIs. This value is invalid when `keep_days` is set.
-  - `keep_days` (integer) - The number of days to keep AMIs. For example, if you specify `10`, AMIs created before 10 days will be deleted. This value is invalid when `keep_releases` is set.
-  - `regions` (array of strings) - A list of regions, such as `us-east-1` in which to manage AMIs. **NOTE:** Before v0.3.0, this parameter was `region`. Since 0.4.0, `region` is not used.
+
+- `tags` (map of strings) - The tags to indetify AMI. This plugin uses search by `tags`. If `tags` matches `AMI` tags, these AMI becomes to management target.
+- `keep_releases` (integer) - The number of AMIs. This value is invalid when `keep_days` is set.
+- `keep_days` (integer) - The number of days to keep AMIs. For example, if you specify `10`, AMIs created before 10 days will be deleted. This value is invalid when `keep_releases` is set.
+- `regions` (array of strings) - A list of regions, such as `us-east-1` in which to manage AMIs. **NOTE:** Before v0.3.0, this parameter was `region`. Since 0.4.0, `region` is not used.
 
 Optional:
-  - `dry_run` (boolean) - If `true`, the post-processor doesn't actually delete AMIs.
+
+- `dry_run` (boolean) - If `true`, the post-processor doesn't actually delete AMIs.
 
 The following attibutes are also available. These are optional and used in the same way as AWS Builder:
 

--- a/cleaner.go
+++ b/cleaner.go
@@ -236,13 +236,22 @@ func (c *Cleaner) genTagsFilter() []*ec2.Filter {
 	var (
 		filters []*ec2.Filter
 	)
-	for k, v := range c.config.Tags {
+	if c.config.Identifier != "" {
 		filters = append(filters, &ec2.Filter{
-			Name: aws.String(fmt.Sprintf("tag:%s", k)),
+			Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
 			Values: []*string{
-				aws.String(v),
+				aws.String(c.config.Identifier),
 			},
 		})
+	} else {
+		for k, v := range c.config.Tags {
+			filters = append(filters, &ec2.Filter{
+				Name: aws.String(fmt.Sprintf("tag:%s", k)),
+				Values: []*string{
+					aws.String(v),
+				},
+			})
+		}
 	}
 	return filters
 }

--- a/cleaner.go
+++ b/cleaner.go
@@ -72,15 +72,9 @@ func NewCleaner(sess *session.Session, config Config) (*Cleaner, error) {
 // Please be aware that these are candidates. Not all images are deleted due to output to the Packer UI.
 func (c *Cleaner) RetrieveCandidateImages() ([]*ec2.Image, error) {
 	log.Println("Describing images")
+	filters := c.genTagsFilter()
 	output, err := c.ec2conn.DescribeImages(&ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
-				Values: []*string{
-					aws.String(c.config.Identifier),
-				},
-			},
-		},
+		Filters: filters,
 	})
 	if err != nil {
 		return nil, err
@@ -236,4 +230,19 @@ func (c *Cleaner) setLaunchTemplateUsed() error {
 		}
 	}
 	return nil
+}
+
+func (c *Cleaner) genTagsFilter() []*ec2.Filter {
+	var (
+		filters []*ec2.Filter
+	)
+	for k, v := range c.config.Tags {
+		filters = append(filters, &ec2.Filter{
+			Name: aws.String(fmt.Sprintf("tag:%s", k)),
+			Values: []*string{
+				aws.String(v),
+			},
+		})
+	}
+	return filters
 }

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -12,120 +12,142 @@ import (
 )
 
 func TestCleaner_RetrieveCandidateImages_KeepReleases(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	ec2mock := NewMockEC2API(ctrl)
-
-	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{
+	var (
+		cfgs = []Config{
 			{
-				Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
-				Values: []*string{
-					aws.String("packer-example"),
+				KeepReleases: 2,
+				Tags: map[string]string{
+					"Amazon_AMI_Management_Identifier": "packer-example",
 				},
 			},
-		},
-	}).Return(&ec2.DescribeImagesOutput{
-		Images: []*ec2.Image{{
-			ImageId:      aws.String("ami-12345a"),
-			CreationDate: aws.String("2016-08-01T15:04:05.000Z"),
-		}, {
-			ImageId:      aws.String("ami-12345b"),
-			CreationDate: aws.String("2016-08-04T15:04:05.000Z"),
-		}, {
-			ImageId:      aws.String("ami-12345c"),
-			CreationDate: aws.String("2016-07-29T15:04:05.000Z"),
-			BlockDeviceMappings: []*ec2.BlockDeviceMapping{{
-				Ebs: &ec2.EbsBlockDevice{
-					SnapshotId: aws.String("snap-12345a"),
+			{
+				KeepReleases: 2,
+				Identifier:   "packer-example",
+			},
+		}
+	)
+	for _, cfg := range cfgs {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ec2mock := NewMockEC2API(ctrl)
+
+		ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+			Filters: []*ec2.Filter{
+				{
+					Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
+					Values: []*string{
+						aws.String("packer-example"),
+					},
 				},
+			},
+		}).Return(&ec2.DescribeImagesOutput{
+			Images: []*ec2.Image{{
+				ImageId:      aws.String("ami-12345a"),
+				CreationDate: aws.String("2016-08-01T15:04:05.000Z"),
 			}, {
-				Ebs: &ec2.EbsBlockDevice{
-					SnapshotId: aws.String("snap-12345b"),
-				},
+				ImageId:      aws.String("ami-12345b"),
+				CreationDate: aws.String("2016-08-04T15:04:05.000Z"),
+			}, {
+				ImageId:      aws.String("ami-12345c"),
+				CreationDate: aws.String("2016-07-29T15:04:05.000Z"),
+				BlockDeviceMappings: []*ec2.BlockDeviceMapping{{
+					Ebs: &ec2.EbsBlockDevice{
+						SnapshotId: aws.String("snap-12345a"),
+					},
+				}, {
+					Ebs: &ec2.EbsBlockDevice{
+						SnapshotId: aws.String("snap-12345b"),
+					},
+				}},
 			}},
-		}},
-	}, nil)
+		}, nil)
 
-	cleaner := &Cleaner{
-		ec2conn: ec2mock,
-		config: Config{
-			Tags: map[string]string{
-				"Amazon_AMI_Management_Identifier": "packer-example",
-			},
-			KeepReleases: 2,
-		},
-		now: time.Now().UTC(),
-	}
+		cleaner := &Cleaner{
+			ec2conn: ec2mock,
+			config:  cfg,
+			now:     time.Now().UTC(),
+		}
 
-	images, err := cleaner.RetrieveCandidateImages()
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	if len(images) != 1 {
-		t.Fatalf("Unexpected image count: %d", len(images))
-	}
-	if *images[0].ImageId != "ami-12345c" {
-		t.Fatalf("Unexpected image: %s", *images[0].ImageId)
+		images, err := cleaner.RetrieveCandidateImages()
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		if len(images) != 1 {
+			t.Fatalf("Unexpected image count: %d", len(images))
+		}
+		if *images[0].ImageId != "ami-12345c" {
+			t.Fatalf("Unexpected image: %s", *images[0].ImageId)
+		}
 	}
 }
 
 func TestCleaner_RetrieveCandidateImages_KeepDays(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	ec2mock := NewMockEC2API(ctrl)
-
-	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{
+	var (
+		cfgs = []Config{
 			{
-				Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
-				Values: []*string{
-					aws.String("packer-example"),
+				KeepDays: 10,
+				Tags: map[string]string{
+					"Amazon_AMI_Management_Identifier": "packer-example",
 				},
 			},
-		},
-	}).Return(&ec2.DescribeImagesOutput{
-		Images: []*ec2.Image{{
-			ImageId:      aws.String("ami-12345a"),
-			CreationDate: aws.String("2016-08-01T15:04:05.000Z"),
-		}, {
-			ImageId:      aws.String("ami-12345b"),
-			CreationDate: aws.String("2016-08-04T15:04:05.000Z"),
-		}, {
-			ImageId:      aws.String("ami-12345c"),
-			CreationDate: aws.String("2016-07-29T15:04:05.000Z"),
-			BlockDeviceMappings: []*ec2.BlockDeviceMapping{{
-				Ebs: &ec2.EbsBlockDevice{
-					SnapshotId: aws.String("snap-12345a"),
+			{
+				KeepDays:   10,
+				Identifier: "packer-example",
+			},
+		}
+	)
+	for _, cfg := range cfgs {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ec2mock := NewMockEC2API(ctrl)
+
+		ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+			Filters: []*ec2.Filter{
+				{
+					Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
+					Values: []*string{
+						aws.String("packer-example"),
+					},
 				},
+			},
+		}).Return(&ec2.DescribeImagesOutput{
+			Images: []*ec2.Image{{
+				ImageId:      aws.String("ami-12345a"),
+				CreationDate: aws.String("2016-08-01T15:04:05.000Z"),
 			}, {
-				Ebs: &ec2.EbsBlockDevice{
-					SnapshotId: aws.String("snap-12345b"),
-				},
+				ImageId:      aws.String("ami-12345b"),
+				CreationDate: aws.String("2016-08-04T15:04:05.000Z"),
+			}, {
+				ImageId:      aws.String("ami-12345c"),
+				CreationDate: aws.String("2016-07-29T15:04:05.000Z"),
+				BlockDeviceMappings: []*ec2.BlockDeviceMapping{{
+					Ebs: &ec2.EbsBlockDevice{
+						SnapshotId: aws.String("snap-12345a"),
+					},
+				}, {
+					Ebs: &ec2.EbsBlockDevice{
+						SnapshotId: aws.String("snap-12345b"),
+					},
+				}},
 			}},
-		}},
-	}, nil)
+		}, nil)
 
-	cleaner := &Cleaner{
-		ec2conn: ec2mock,
-		config: Config{
-			Tags: map[string]string{
-				"Amazon_AMI_Management_Identifier": "packer-example",
-			},
-			KeepDays: 10,
-		},
-		now: time.Date(2016, time.August, 11, 11, 0, 0, 0, time.UTC),
-	}
+		cleaner := &Cleaner{
+			ec2conn: ec2mock,
+			config:  cfg,
+			now:     time.Date(2016, time.August, 11, 11, 0, 0, 0, time.UTC),
+		}
 
-	images, err := cleaner.RetrieveCandidateImages()
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	if len(images) != 1 {
-		t.Fatalf("Unexpected image count: %d", len(images))
-	}
-	if *images[0].ImageId != "ami-12345c" {
-		t.Fatalf("Unexpected image: %s", *images[0].ImageId)
+		images, err := cleaner.RetrieveCandidateImages()
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		if len(images) != 1 {
+			t.Fatalf("Unexpected image count: %d", len(images))
+		}
+		if *images[0].ImageId != "ami-12345c" {
+			t.Fatalf("Unexpected image: %s", *images[0].ImageId)
+		}
 	}
 }
 

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -50,7 +50,9 @@ func TestCleaner_RetrieveCandidateImages_KeepReleases(t *testing.T) {
 	cleaner := &Cleaner{
 		ec2conn: ec2mock,
 		config: Config{
-			Identifier:   "packer-example",
+			Tags: map[string]string{
+				"Amazon_AMI_Management_Identifier": "packer-example",
+			},
 			KeepReleases: 2,
 		},
 		now: time.Now().UTC(),
@@ -107,8 +109,10 @@ func TestCleaner_RetrieveCandidateImages_KeepDays(t *testing.T) {
 	cleaner := &Cleaner{
 		ec2conn: ec2mock,
 		config: Config{
-			Identifier: "packer-example",
-			KeepDays:   10,
+			Tags: map[string]string{
+				"Amazon_AMI_Management_Identifier": "packer-example",
+			},
+			KeepDays: 10,
 		},
 		now: time.Date(2016, time.August, 11, 11, 0, 0, 0, time.UTC),
 	}

--- a/config.go
+++ b/config.go
@@ -13,11 +13,11 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	AccessConfig        `mapstructure:",squash"`
 
-	Identifier   string   `mapstructure:"identifier"`
-	KeepReleases int      `mapstructure:"keep_releases"`
-	KeepDays     int      `mapstructure:"keep_days"`
-	Regions      []string `mapstructure:"regions"`
-	DryRun       bool     `mapstructure:"dry_run"`
+	KeepReleases int               `mapstructure:"keep_releases"`
+	KeepDays     int               `mapstructure:"keep_days"`
+	Regions      []string          `mapstructure:"regions"`
+	DryRun       bool              `mapstructure:"dry_run"`
+	Tags         map[string]string `mapstructure:"tags"`
 
 	ctx interpolate.Context
 }

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	AccessConfig        `mapstructure:",squash"`
 
+	Identifier   string            `mapstructure:"identifier"`
 	KeepReleases int               `mapstructure:"keep_releases"`
 	KeepDays     int               `mapstructure:"keep_days"`
 	Regions      []string          `mapstructure:"regions"`

--- a/config.hcl2spec.go
+++ b/config.hcl2spec.go
@@ -64,11 +64,11 @@ type FlatConfig struct {
 	SkipMetadataAPICheck *bool                 `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	Token                *string               `mapstructure:"token" cty:"token" hcl:"token"`
 	SkipValidation       *bool                 `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
-	Identifier           *string               `mapstructure:"identifier" cty:"identifier" hcl:"identifier"`
 	KeepReleases         *int                  `mapstructure:"keep_releases" cty:"keep_releases" hcl:"keep_releases"`
 	KeepDays             *int                  `mapstructure:"keep_days" cty:"keep_days" hcl:"keep_days"`
 	Regions              []string              `mapstructure:"regions" cty:"regions" hcl:"regions"`
 	DryRun               *bool                 `mapstructure:"dry_run" cty:"dry_run" hcl:"dry_run"`
+	Tags                 map[string]string     `mapstructure:"tags" cty:"tags" hcl:"tags"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -100,11 +100,11 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"skip_metadata_api_check":    &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"token":                      &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"skip_region_validation":     &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
-		"identifier":                 &hcldec.AttrSpec{Name: "identifier", Type: cty.String, Required: false},
 		"keep_releases":              &hcldec.AttrSpec{Name: "keep_releases", Type: cty.Number, Required: false},
 		"keep_days":                  &hcldec.AttrSpec{Name: "keep_days", Type: cty.Number, Required: false},
 		"regions":                    &hcldec.AttrSpec{Name: "regions", Type: cty.List(cty.String), Required: false},
 		"dry_run":                    &hcldec.AttrSpec{Name: "dry_run", Type: cty.Bool, Required: false},
+		"tags":                       &hcldec.AttrSpec{Name: "tags", Type: cty.Map(cty.String), Required: false},
 	}
 	return s
 }

--- a/config.hcl2spec.go
+++ b/config.hcl2spec.go
@@ -64,6 +64,7 @@ type FlatConfig struct {
 	SkipMetadataAPICheck *bool                 `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	Token                *string               `mapstructure:"token" cty:"token" hcl:"token"`
 	SkipValidation       *bool                 `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
+	Identifier           *string               `mapstructure:"identifier" cty:"identifier" hcl:"identifier"`
 	KeepReleases         *int                  `mapstructure:"keep_releases" cty:"keep_releases" hcl:"keep_releases"`
 	KeepDays             *int                  `mapstructure:"keep_days" cty:"keep_days" hcl:"keep_days"`
 	Regions              []string              `mapstructure:"regions" cty:"regions" hcl:"regions"`
@@ -100,6 +101,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"skip_metadata_api_check":    &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"token":                      &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"skip_region_validation":     &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
+		"identifier":                 &hcldec.AttrSpec{Name: "identifier", Type: cty.String, Required: false},
 		"keep_releases":              &hcldec.AttrSpec{Name: "keep_releases", Type: cty.Number, Required: false},
 		"keep_days":                  &hcldec.AttrSpec{Name: "keep_days", Type: cty.Number, Required: false},
 		"regions":                    &hcldec.AttrSpec{Name: "regions", Type: cty.List(cty.String), Required: false},

--- a/post-processor.go
+++ b/post-processor.go
@@ -42,8 +42,8 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		return err
 	}
 
-	if p.config.Identifier == "" {
-		return errors.New("empty `identifier` is not allowed. Please make sure that it is set correctly")
+	if len(p.config.Tags) == 0 {
+		return errors.New("empty `tags` is not allowed. Please make sure that it is set correctly")
 	}
 	if p.config.KeepReleases != 0 && p.config.KeepDays != 0 {
 		return errors.New("`keep_releases` and `keep_days` cannot be set as the same time")
@@ -65,7 +65,11 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 }
 
 // PostProcess deletes old AMI and snapshot so as to maintain the number of AMIs expected
-func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
+func (p *PostProcessor) PostProcess(
+	ctx context.Context,
+	ui packer.Ui,
+	artifact packer.Artifact,
+) (packer.Artifact, bool, bool, error) {
 	log.Println("Running the post-processor")
 
 	for _, region := range p.config.Regions {

--- a/post-processor.go
+++ b/post-processor.go
@@ -42,8 +42,11 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		return err
 	}
 
-	if len(p.config.Tags) == 0 {
-		return errors.New("empty `tags` is not allowed. Please make sure that it is set correctly")
+	if len(p.config.Tags) == 0 && p.config.Identifier == "" {
+		return errors.New("`identifier` or `tags` must be defined. Please make sure that it is set correctly")
+	}
+	if len(p.config.Tags) > 0 && p.config.Identifier != "" {
+		log.Println("[WARNING] `tags` is ignored because `identifier` is defined")
 	}
 	if p.config.KeepReleases != 0 && p.config.KeepDays != 0 {
 		return errors.New("`keep_releases` and `keep_days` cannot be set as the same time")

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -26,8 +26,10 @@ func TestPostProcessor_Configure_validConfigWithKeepReleases(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
 		"regions":       []string{"us-east-1"},
-		"identifier":    "packer-example",
 		"keep_releases": 3,
+		"tags": map[string]string{
+			"Amazon_AMI_Management_Identifier": "packer-example",
+		},
 	})
 
 	if err != nil {
@@ -38,9 +40,11 @@ func TestPostProcessor_Configure_validConfigWithKeepReleases(t *testing.T) {
 func TestPostProcessor_Configure_validConfigWithKeepDays(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
-		"regions":    []string{"us-east-1"},
-		"identifier": "packer-example",
-		"keep_days":  10,
+		"regions":   []string{"us-east-1"},
+		"keep_days": 10,
+		"tags": map[string]string{
+			"Amazon_AMI_Management_Identifier": "packer-example",
+		},
 	})
 
 	if err != nil {
@@ -51,7 +55,9 @@ func TestPostProcessor_Configure_validConfigWithKeepDays(t *testing.T) {
 func TestPostProcessor_Configure_missingRegions(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
-		"identifier":    "packer-example",
+		"tags": map[string]string{
+			"Amazon_AMI_Management_Identifier": "packer-example",
+		},
 		"keep_releases": 3,
 	})
 
@@ -73,7 +79,7 @@ func TestPostProcessor_Configure_emptyIdentifier(t *testing.T) {
 	if err == nil {
 		t.Fatal("should cause validation errors")
 	}
-	if err.Error() != "empty `identifier` is not allowed. Please make sure that it is set correctly" {
+	if err.Error() != "empty `tags` is not allowed. Please make sure that it is set correctly" {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 }
@@ -82,8 +88,10 @@ func TestPostProcessor_Configure_invalidKeepReleases(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
 		"regions":       []string{"us-east-1"},
-		"identifier":    "packer-example",
 		"keep_releases": -1,
+		"tags": map[string]string{
+			"Amazon_AMI_Management_Identifier": "packer-example",
+		},
 	})
 
 	if err == nil {
@@ -97,9 +105,11 @@ func TestPostProcessor_Configure_invalidKeepReleases(t *testing.T) {
 func TestPostProcessor_Configure_invalidKeepDays(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
-		"regions":    []string{"us-east-1"},
-		"identifier": "packer-example",
-		"keep_days":  -1,
+		"regions":   []string{"us-east-1"},
+		"keep_days": -1,
+		"tags": map[string]string{
+			"Amazon_AMI_Management_Identifier": "packer-example",
+		},
 	})
 
 	if err == nil {
@@ -114,9 +124,11 @@ func TestPostProcessor_Configure_setKeepReleasesAndKeepDays(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
 		"regions":       []string{"us-east-1"},
-		"identifier":    "packer-example",
 		"keep_releases": 3,
 		"keep_days":     10,
+		"tags": map[string]string{
+			"Amazon_AMI_Management_Identifier": "packer-example",
+		},
 	})
 
 	if err == nil {
@@ -130,8 +142,10 @@ func TestPostProcessor_Configure_setKeepReleasesAndKeepDays(t *testing.T) {
 func TestPostProcessor_Configure_NeitherKeepReleasesNorKeepDaysIsSet(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
-		"regions":    []string{"us-east-1"},
-		"identifier": "packer-example",
+		"regions": []string{"us-east-1"},
+		"tags": map[string]string{
+			"Amazon_AMI_Management_Identifier": "packer-example",
+		},
 	})
 
 	if err == nil {

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -22,141 +22,173 @@ func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
 	var _ packer.PostProcessor = new(PostProcessor)
 }
 
-func TestPostProcessor_Configure_validConfigWithKeepReleases(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"regions":       []string{"us-east-1"},
-		"keep_releases": 3,
-		"tags": map[string]string{
+func TestConfigCases(t *testing.T) {
+	var (
+		defaultRegions    = []string{"us-east-1"}
+		defaultIndentifer = "packer-example"
+		defaultTags       = map[string]string{
 			"Amazon_AMI_Management_Identifier": "packer-example",
-		},
-	})
+		}
 
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-}
+		configTestCases = []struct {
+			Name           string
+			ExptectedError string
+			Config         map[string]interface{}
+		}{
+			{
+				Name:           "Missing Regions",
+				ExptectedError: "empty `regions` is not allowed. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"identifier":    defaultIndentifer,
+					"keep_releases": 3,
+				},
+			},
+			{
+				Name:           "Missing Regions",
+				ExptectedError: "empty `regions` is not allowed. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"tags":          defaultTags,
+					"keep_releases": 3,
+				},
+			},
+			{
+				Name:           "Invalid KeepReleases",
+				ExptectedError: "`keep_releases` must be greater than 1. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"identifier":    defaultIndentifer,
+					"keep_releases": -1,
+				},
+			},
+			{
+				Name:           "Invalid KeepReleases",
+				ExptectedError: "`keep_releases` must be greater than 1. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"tags":          defaultTags,
+					"keep_releases": -1,
+				},
+			},
+			{
+				Name:           "Invalid KeepDays",
+				ExptectedError: "`keep_days` must be greater than 1. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"regions":    defaultRegions,
+					"identifier": defaultIndentifer,
+					"keep_days":  -1,
+				},
+			},
+			{
+				Name:           "Invalid KeepDays",
+				ExptectedError: "`keep_days` must be greater than 1. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"regions":   defaultRegions,
+					"tags":      defaultTags,
+					"keep_days": -1,
+				},
+			},
+			{
+				Name:           "Set KeepReleases and KeepDays",
+				ExptectedError: "`keep_releases` and `keep_days` cannot be set as the same time",
+				Config: map[string]interface{}{
+					"regions":       defaultRegions,
+					"identifier":    defaultIndentifer,
+					"keep_releases": 3,
+					"keep_days":     10,
+				},
+			},
+			{
+				Name:           "Set KeepReleases and KeepDays",
+				ExptectedError: "`keep_releases` and `keep_days` cannot be set as the same time",
+				Config: map[string]interface{}{
+					"regions":       defaultRegions,
+					"tags":          defaultTags,
+					"keep_releases": 3,
+					"keep_days":     10,
+				},
+			},
+			{
+				Name:           "Neither KeepReleases nor KeepDays is set",
+				ExptectedError: "`keep_releases` or `keep_days` must be greater than 1. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"regions":    defaultRegions,
+					"identifier": defaultIndentifer,
+				},
+			},
+			{
+				Name:           "validate config with tags",
+				ExptectedError: "`keep_releases` or `keep_days` must be greater than 1. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"regions": defaultRegions,
+					"tags":    defaultTags,
+				},
+			},
+			{
+				Name:           "Empty Identifier and Tags",
+				ExptectedError: "`identifier` or `tags` must be defined. Please make sure that it is set correctly",
+				Config: map[string]interface{}{
+					"regions":       defaultRegions,
+					"keep_releases": 3,
+				},
+			},
+			{
+				Name: "Configure valid config with KeepDays",
+				Config: map[string]interface{}{
+					"regions":    defaultRegions,
+					"identifier": defaultIndentifer,
+					"keep_days":  10,
+				},
+			},
+			{
+				Name: "Configure valid config with KeepDays",
+				Config: map[string]interface{}{
+					"regions":   defaultRegions,
+					"tags":      defaultTags,
+					"keep_days": 10,
+				},
+			},
+			{
+				Name: "Configure valid config with KeepReleases",
+				Config: map[string]interface{}{
+					"regions":       defaultRegions,
+					"identifier":    defaultIndentifer,
+					"keep_releases": 3,
+				},
+			},
+			{
+				Name: "Configure valid config with KeepReleases",
+				Config: map[string]interface{}{
+					"regions":       defaultRegions,
+					"tags":          defaultTags,
+					"keep_releases": 3,
+				},
+			},
+		}
+	)
 
-func TestPostProcessor_Configure_validConfigWithKeepDays(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"regions":   []string{"us-east-1"},
-		"keep_days": 10,
-		"tags": map[string]string{
-			"Amazon_AMI_Management_Identifier": "packer-example",
-		},
-	})
-
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-}
-
-func TestPostProcessor_Configure_missingRegions(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"tags": map[string]string{
-			"Amazon_AMI_Management_Identifier": "packer-example",
-		},
-		"keep_releases": 3,
-	})
-
-	if err == nil {
-		t.Fatal("should cause validation errors")
-	}
-	if err.Error() != "empty `regions` is not allowed. Please make sure that it is set correctly" {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-}
-
-func TestPostProcessor_Configure_emptyIdentifier(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"regions":       []string{"us-east-1"},
-		"keep_releases": 3,
-	})
-
-	if err == nil {
-		t.Fatal("should cause validation errors")
-	}
-	if err.Error() != "empty `tags` is not allowed. Please make sure that it is set correctly" {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-}
-
-func TestPostProcessor_Configure_invalidKeepReleases(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"regions":       []string{"us-east-1"},
-		"keep_releases": -1,
-		"tags": map[string]string{
-			"Amazon_AMI_Management_Identifier": "packer-example",
-		},
-	})
-
-	if err == nil {
-		t.Fatal("should cause validation errors")
-	}
-	if err.Error() != "`keep_releases` must be greater than 1. Please make sure that it is set correctly" {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-}
-
-func TestPostProcessor_Configure_invalidKeepDays(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"regions":   []string{"us-east-1"},
-		"keep_days": -1,
-		"tags": map[string]string{
-			"Amazon_AMI_Management_Identifier": "packer-example",
-		},
-	})
-
-	if err == nil {
-		t.Fatal("should cause validation errors")
-	}
-	if err.Error() != "`keep_days` must be greater than 1. Please make sure that it is set correctly" {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-}
-
-func TestPostProcessor_Configure_setKeepReleasesAndKeepDays(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"regions":       []string{"us-east-1"},
-		"keep_releases": 3,
-		"keep_days":     10,
-		"tags": map[string]string{
-			"Amazon_AMI_Management_Identifier": "packer-example",
-		},
-	})
-
-	if err == nil {
-		t.Fatal("should cause validation errors")
-	}
-	if err.Error() != "`keep_releases` and `keep_days` cannot be set as the same time" {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-}
-
-func TestPostProcessor_Configure_NeitherKeepReleasesNorKeepDaysIsSet(t *testing.T) {
-	p := new(PostProcessor)
-	err := p.Configure(map[string]interface{}{
-		"regions": []string{"us-east-1"},
-		"tags": map[string]string{
-			"Amazon_AMI_Management_Identifier": "packer-example",
-		},
-	})
-
-	if err == nil {
-		t.Fatal("should cause validation errors")
-	}
-	if err.Error() != "`keep_releases` or `keep_days` must be greater than 1. Please make sure that it is set correctly" {
-		t.Fatalf("Unexpected error occurred: %s", err)
+	for _, c := range configTestCases {
+		t.Run(c.Name, func(t *testing.T) {
+			p := new(PostProcessor)
+			err := p.Configure(c.Config)
+			if c.ExptectedError != "" {
+				if err == nil {
+					t.Fatalf("case: %s should cause validation errors", c.Name)
+				}
+				if err.Error() != c.ExptectedError {
+					t.Fatalf("case: %s unexpected error occurred: %s", err, c.Name)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("case: %s unexpected error occurred: %s", err, c.Name)
+				}
+			}
+		})
 	}
 }
 
 func TestPostProcessor_PostProcess(t *testing.T) {
+	var (
+		defaultRegions = []string{"us-east-1"}
+	)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	cleanermock := NewMockCleanable(ctrl)
@@ -179,7 +211,7 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 		testMode: true,
 		cleaner:  cleanermock,
 		config: Config{
-			Regions: []string{"us-east-1"},
+			Regions: defaultRegions,
 		},
 	}
 


### PR DESCRIPTION
# Why
The approach with hardcoded `identifier` (i.e. `Amazon_AMI_Management_Identifier`) isn't suitable for packer builds with a long history.