### PR TITLE
Remove VersionPrerelease

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var (
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.


### PR DESCRIPTION
Fixes https://github.com/wata727/packer-plugin-amazon-ami-management/issues/408

Packer v1.11 no longer supports remote installation of pre-release versions.
https://github.com/hashicorp/packer/releases/tag/v1.11.0

Normally this limitation would not be relevant for this plugin, but we had an issue where the `VersionPrerelease` ported from the scaffolding still existed, which was causing the plugin to be identified internally as a pre-release (1.4.1-dev).

This PR removes `VersionPrerelease` and fix it so that it is not internally detected as a prerelease.