### PR TITLE
Add new resolve_aliases option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.6.0 (2024-09-29)
+
+### Enhancements
+
+- [#431](https://github.com/wata727/packer-plugin-amazon-ami-management/pull/431): Add new `resolve_aliases` option.
+  - If `true`, the post-processor resolves the AWS Systems Manager parameter when the launch template uses it to specify the AMI ID. See [AWS documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/using-systems-manager-parameters.html).
+
 ## v1.5.0 (2024-06-03)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The post-processor requires additional permissions to work. Below is the differe
         "ec2:RegisterImage",
         "ec2:RunInstances",
         "ec2:StopInstances",
-        "ec2:TerminateInstances"
+        "ec2:TerminateInstances",
 +       "ssm:GetParameters" // If "resolve_aliases" is enabled
       ],
       "Resource" : "*"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,41 @@ build {
 }
 ```
 
+### An example with defined option `resolve_aliases`
+
+When using AWS Systems Manager parameters instead of AMI IDs in launch templates (See the [AWS documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/using-systems-manager-parameters.html)), it is essential to set the `resolve_aliases` option to `true`. This allows the post-processor to resolve the SSM Parameter and retrieve the actual AMI ID associated with it.
+
+If `resolve_aliases` is not set to `true`, the post-processor will not detect the actual AMI ID usage, leading to potential deletion of the AMI and its related snapshot, even if they are still in use by the launch template.
+
+```hcl
+source "amazon-ebs" "example" {
+  region        = "us-east-1"
+  source_ami    = "ami-6869aa05"
+  instance_type = "t2.micro"
+  ssh_username  = "ec2-user"
+  ssh_pty       = true
+  ami_name      = "packer-example ${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  tags = {
+    Amazon_AMI_Management_Identifier = "packer-example"
+  }
+}
+
+build {
+  sources = ["source.amazon-ebs.example"]
+
+  provisioner "shell" {
+    inline = ["echo 'running...'"]
+  }
+
+  post-processor "amazon-ami-management" {
+    regions         = ["us-east-1"]
+    identifier      = "packer-example"
+    keep_releases   = 3
+    resolve_aliases = true
+  }
+}
+```
+
 ### Configuration
 
 Type: `amazon-ami-management`
@@ -110,6 +145,7 @@ Required:
 
 Optional:
 
+- `resolve_aliases` (boolean) - If `true`, the post-processor resolves the AWS Systems Manager parameter when the launch template uses it to specify the AMI ID. See [AWS documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/using-systems-manager-parameters.html). **Important**: If you set this to `true`, you must add `ssm:GetParameters` permission to the IAM Role.
 - `dry_run` (boolean) - If `true`, the post-processor doesn't actually delete AMIs.
 
 The following attibutes are also available. These are optional and used in the same way as AWS Builder:
@@ -174,6 +210,50 @@ The post-processor requires additional permissions to work. Below is the differe
   }]
 }
 ```
+
+Add this additional IAM Policy to the IAM Role if you set `resolve_aliases` to `true`
+
+```json
+{
+    "Statement": [
+        {
+            "Action": [
+                "ssm:GetParameters"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}
+```
+
+As a best practice you can restrict the permission to only a specific subgroup of parameters.
+
+```json
+{
+    "Statement": [
+        {
+            "Action": [
+                "ssm:GetParameters"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:ssm:${region}:${accountId}:parameter/company-amis/*"
+        }
+    ],
+    "Version": "2012-10-17"
+}
+```
+
+NOTE: Replace `${region}` and `${accountId}` with the correct values.
+
+In the previous example. We give access to all parameters whose name begin with `/company-amis/`. For example if you had the following parameters:
+
+* /company-amis/wordpress/windows
+* /company-amis/wordpress/linux
+* /cool-service/db-password
+
+This permission would give access to `/company-amis/wordpress/windows` and `/company-amis/jomla/linux` parameters. But not to `/cool-service/db-password` parameter.
 
 ## Developing Plugin
 

--- a/config.go
+++ b/config.go
@@ -13,12 +13,13 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	AccessConfig        `mapstructure:",squash"`
 
-	Identifier   string            `mapstructure:"identifier"`
-	KeepReleases int               `mapstructure:"keep_releases"`
-	KeepDays     int               `mapstructure:"keep_days"`
-	Regions      []string          `mapstructure:"regions"`
-	DryRun       bool              `mapstructure:"dry_run"`
-	Tags         map[string]string `mapstructure:"tags"`
+	Identifier     string            `mapstructure:"identifier"`
+	KeepReleases   int               `mapstructure:"keep_releases"`
+	KeepDays       int               `mapstructure:"keep_days"`
+	ResolveAliases bool              `mapstructure:"resolve_aliases"`
+	Regions        []string          `mapstructure:"regions"`
+	DryRun         bool              `mapstructure:"dry_run"`
+	Tags           map[string]string `mapstructure:"tags"`
 
 	ctx interpolate.Context
 }

--- a/config.hcl2spec.go
+++ b/config.hcl2spec.go
@@ -67,6 +67,7 @@ type FlatConfig struct {
 	Identifier           *string               `mapstructure:"identifier" cty:"identifier" hcl:"identifier"`
 	KeepReleases         *int                  `mapstructure:"keep_releases" cty:"keep_releases" hcl:"keep_releases"`
 	KeepDays             *int                  `mapstructure:"keep_days" cty:"keep_days" hcl:"keep_days"`
+	ResolveAliases       *bool                 `mapstructure:"resolve_aliases" cty:"resolve_aliases" hcl:"resolve_aliases"`
 	Regions              []string              `mapstructure:"regions" cty:"regions" hcl:"regions"`
 	DryRun               *bool                 `mapstructure:"dry_run" cty:"dry_run" hcl:"dry_run"`
 	Tags                 map[string]string     `mapstructure:"tags" cty:"tags" hcl:"tags"`
@@ -104,6 +105,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"identifier":                 &hcldec.AttrSpec{Name: "identifier", Type: cty.String, Required: false},
 		"keep_releases":              &hcldec.AttrSpec{Name: "keep_releases", Type: cty.Number, Required: false},
 		"keep_days":                  &hcldec.AttrSpec{Name: "keep_days", Type: cty.Number, Required: false},
+		"resolve_aliases":            &hcldec.AttrSpec{Name: "resolve_aliases", Type: cty.Bool, Required: false},
 		"regions":                    &hcldec.AttrSpec{Name: "regions", Type: cty.List(cty.String), Required: false},
 		"dry_run":                    &hcldec.AttrSpec{Name: "dry_run", Type: cty.Bool, Required: false},
 		"tags":                       &hcldec.AttrSpec{Name: "tags", Type: cty.Map(cty.String), Required: false},

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -161,6 +161,42 @@ func TestConfigCases(t *testing.T) {
 					"keep_releases": 3,
 				},
 			},
+			{
+				Name: "Configure valid config with ResolveAliases set to true",
+				Config: map[string]interface{}{
+					"regions":         defaultRegions,
+					"tags":            defaultTags,
+					"keep_releases":   3,
+					"resolve_aliases": true,
+				},
+			},
+			{
+				Name: "Configure valid config with ResolveAliases set to false",
+				Config: map[string]interface{}{
+					"regions":         defaultRegions,
+					"tags":            defaultTags,
+					"keep_releases":   3,
+					"resolve_aliases": false,
+				},
+			},
+			{
+				Name: "Configure valid config with ResolveAliases set to true",
+				Config: map[string]interface{}{
+					"regions":         defaultRegions,
+					"tags":            defaultTags,
+					"keep_days":       10,
+					"resolve_aliases": true,
+				},
+			},
+			{
+				Name: "Configure valid config with ResolveAliases set to false",
+				Config: map[string]interface{}{
+					"regions":         defaultRegions,
+					"tags":            defaultTags,
+					"keep_days":       10,
+					"resolve_aliases": false,
+				},
+			},
 		}
 	)
 

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -179,24 +179,6 @@ func TestConfigCases(t *testing.T) {
 					"resolve_aliases": false,
 				},
 			},
-			{
-				Name: "Configure valid config with ResolveAliases set to true",
-				Config: map[string]interface{}{
-					"regions":         defaultRegions,
-					"tags":            defaultTags,
-					"keep_days":       10,
-					"resolve_aliases": true,
-				},
-			},
-			{
-				Name: "Configure valid config with ResolveAliases set to false",
-				Config: map[string]interface{}{
-					"regions":         defaultRegions,
-					"tags":            defaultTags,
-					"keep_days":       10,
-					"resolve_aliases": false,
-				},
-			},
 		}
 	)
 


### PR DESCRIPTION
Enhancement proposed in #430

## Problem Statement

When a launch template uses AWS Systems Manager (SSM) parameters to reference AMI IDs instead of hardcoding them, the `Cleaner::setLaunchTemplateUsed()` method fails to detect the actual AMI ID as being in use. See [AWS documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/using-systems-manager-parameters.html).

![diagram](https://github.com/user-attachments/assets/5c543631-034a-4934-a5c9-efab322f37ef)

This is because the `DescribeLaunchTemplateVersions` call only resolves the SSM parameter to its actual value if the `ResolveAlias` argument is set to `true`. Otherwise, it returns the parameter name in the format `resolve:ssm:/my-amis/wordpress/ubuntu`.

However, setting `ResolveAlias` to `true` requires specifying a single launch template version, which means we need to make an additional `DescribeLaunchTemplateVersions` call for each launch template version that uses an SSM parameter.

## Solution

To address this issue, I introduced a new `Cleaner::resolveImageAlias()` method that performs the additional `DescribeLaunchTemplateVersions` request while keeping track of already resolved parameters to avoid unnecessary repeated calls.

Here's an example of the additional request:

```go
// If have not been already resolved, resolve the alias.
aliasedVersions, err := c.ec2conn.DescribeLaunchTemplateVersions(&ec2.DescribeLaunchTemplateVersionsInput{
	LaunchTemplateId: launchTemplateId,
	Versions: []*string{
		aws.String(strconv.FormatInt(*launchTemplateVersion, 10)),
	},
	ResolveAlias: aws.Bool(true),
})
```

## Additional Notes

* I updated the README.md file to describe this use case and provide guidance on configuring the plugin when using this new feature.
* I added recommendations for the necessary IAM role permissions to make this feature work.
* I added new tests for the new functionallity.
* I updated the CHANGELOG.md with a brief description of the new feature.
