### PR TITLE
Fix GoReleaser build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v6
       with:
         version: latest
-        args: release --rm-dist
+        args: release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}


### PR DESCRIPTION
See https://goreleaser.com/blog/goreleaser-v2/#upgrading

```
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser' failed with exit code 1
```

https://github.com/wata727/packer-plugin-amazon-ami-management/actions/runs/11324352628/job/31488986321