### PR TITLE
Improve developing plugin documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+packer-plugin-amazon-ami-management

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ NAME=amazon-ami-management
 BINARY=packer-plugin-${NAME}
 MOCK_VERSION?=$(shell go list -m github.com/golang/mock | cut -d " " -f2)
 SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
+PLUGIN_FQN=$(shell grep -E '^module' <go.mod | sed -E 's/module \s*//')
 
 deps:
 	go install github.com/golang/mock/mockgen@${MOCK_VERSION}
@@ -19,8 +20,7 @@ build: test
 	go build -v
 
 install: build
-	mkdir -p ~/.packer.d/plugins
-	mv ./packer-plugin-amazon-ami-management ~/.packer.d/plugins/
+	packer plugins install --path ${BINARY} "$(shell echo "${PLUGIN_FQN}" | sed 's/packer-plugin-//')"
 
 plugin-check: deps build
 	packer-sdc plugin-check ${BINARY}

--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ The post-processor requires additional permissions to work. Below is the differe
 
 ## Developing Plugin
 
-If you want to build this plugin on your environment, you can use GNU Make build system.
-This Makefile depends on [Go](https://golang.org/) 1.23 or more. At First, you should install Go.
+To use the plugin built locally with Packer, you can use `make install`.
 
 ```
-$ make build
+$ make install
 ```
+
+This command runs `go build` to generate the plugin binary and then installs the plugin with `packer plugins install`. This requires that you have Go v1.23+ and Packer v1.7+ installed.


### PR DESCRIPTION
In the latest Packer, even if you put built plugins in `~/.packer.d/plugins`, they will not be loaded. You should use `packer plugins install` instead.
This PR changes the developer guide so that `make install` runs `packer plugins install` instead of moving the binary to `~/.packer.d/plugins`.